### PR TITLE
Slashify the weeb.sh commands

### DIFF
--- a/KekBot/Commands/PingCommand.cs
+++ b/KekBot/Commands/PingCommand.cs
@@ -1,18 +1,21 @@
-﻿using DSharpPlus.CommandsNext;
-using DSharpPlus.CommandsNext.Attributes;
+﻿using DSharpPlus;
+using DSharpPlus.Entities;
+using DSharpPlus.SlashCommands;
 using System.Threading.Tasks;
 
 namespace KekBot.Commands {
-    public class PingCommand : BaseCommandModule {
+    public class PingCommand : ApplicationCommandModule {
 
-        [Command("ping"), Description("Returns with the bot's ping."), Aliases("pong")]
-        async Task Ping(CommandContext ctx) {
-            var msg = await ctx.RespondAsync("Pinging...");
-            var ping = msg.CreationTimestamp - ctx.Message.CreationTimestamp;
-            var heartbeat = ctx.Client.Ping;
+        [SlashCommand("ping", "Returns with the bot's ping.")]
+        async Task Ping(InteractionContext ctx)
+        {
+            await ctx.CreateResponseAsync(InteractionResponseType.ChannelMessageWithSource,
+                new DiscordInteractionResponseBuilder().WithContent("Pinging..."));
+            var msg = await ctx.GetOriginalResponseAsync();
+            var ping = msg.CreationTimestamp - ctx.Interaction.CreationTimestamp;
             await msg.ModifyAsync(
                 $"🏓 Pong! `{ping.TotalMilliseconds}ms`\n" +
-                $"💓 Heartbeat: `{heartbeat}ms`"
+                $"💓 Heartbeat: `{ctx.Client.Ping}ms`"
             );
         }
 

--- a/KekBot/Commands/PingCommand.cs
+++ b/KekBot/Commands/PingCommand.cs
@@ -9,14 +9,13 @@ namespace KekBot.Commands {
         [SlashCommand("ping", "Returns with the bot's ping.")]
         async Task Ping(InteractionContext ctx)
         {
-            await ctx.CreateResponseAsync(InteractionResponseType.ChannelMessageWithSource,
-                new DiscordInteractionResponseBuilder().WithContent("Pinging..."));
+            await ctx.CreateResponseAsync(InteractionResponseType.DeferredChannelMessageWithSource);
             var msg = await ctx.GetOriginalResponseAsync();
             var ping = msg.CreationTimestamp - ctx.Interaction.CreationTimestamp;
-            await msg.ModifyAsync(
+            await ctx.EditResponseAsync(new DiscordWebhookBuilder().WithContent(
                 $"🏓 Pong! `{ping.TotalMilliseconds}ms`\n" +
                 $"💓 Heartbeat: `{ctx.Client.Ping}ms`"
-            );
+            ));
         }
 
     }

--- a/KekBot/Commands/PingCommand.cs
+++ b/KekBot/Commands/PingCommand.cs
@@ -9,7 +9,7 @@ namespace KekBot.Commands {
         [SlashCommand("ping", "Returns with the bot's ping.")]
         async Task Ping(InteractionContext ctx)
         {
-            await ctx.CreateResponseAsync(InteractionResponseType.DeferredChannelMessageWithSource);
+            await ctx.SendThinking();
             var msg = await ctx.GetOriginalResponseAsync();
             var ping = msg.CreationTimestamp - ctx.Interaction.CreationTimestamp;
             await ctx.EditResponseAsync(new DiscordWebhookBuilder().WithContent(

--- a/KekBot/Commands/WeebCommands.cs
+++ b/KekBot/Commands/WeebCommands.cs
@@ -9,299 +9,214 @@ using Weeb.net.Data;
 using DSharpPlus.CommandsNext;
 using DSharpPlus.CommandsNext.Attributes;
 using DSharpPlus.Entities;
+using DSharpPlus.SlashCommands;
+using DSharpPlus.SlashCommands.Attributes;
 using KekBot.Arguments;
 using KekBot.Attributes;
 using KekBot.Lib;
 using KekBot.Utils;
 
 namespace KekBot.Commands {
-    class WeebCommands : BaseCommandModule, IHasFakeCommands, INeedsInitialized {
+    [SlashCommandGroup("weeb", "Powered by Weeb.sh!")]
+    class WeebCommands : ApplicationCommandModule {
 
-        internal static readonly WeebCmdInfo[] FakeCommandInfo = new WeebCmdInfo[] {
-            new WeebCmdInfo("awoo", "AWOOOOOOOOO",
-                "AWOOOOO"),
-            new WeebCmdInfo("bite", "Bites the living HECK out of someone.",
-                "{0} was bit by {1}!", mentionsUser: true),
-            new WeebCmdInfo("cry", ":(((((((",
-                ":CCCCCCC"),
-            new WeebCmdInfo("cuddle", "Cuddles a person.",
-                "{0} was cuddled by {1}.", mentionsUser: true),
-            new WeebCmdInfo("dab", "<o/",
-                @"<o/ \o>"),
-            new WeebCmdInfo("dance", "ᕕ( ᐛ )ᕗ",
-                "ᕕ( ᐛ )ᕗ"),
-            new WeebCmdInfo("deredere", "Because we couldn't get a tsundere command",
-                "❤❤❤❤"),
-            new WeebCmdInfo("hug", "Hugs a person.",
-                "{0} was hugged by {1}.", mentionsUser: true),
-            new WeebCmdInfo("kiss", "Kisses a person.",
-                "{0} was kissed by {1}.", mentionsUser: true),
-            new WeebCmdInfo("lewd", "For those l-lewd moments...",
-                "Did someone say l-lewd?"),
-            new WeebCmdInfo("lick", "Licks a person.",
-                "{0} was licked by {1}!", mentionsUser: true),
-            new WeebCmdInfo("neko", "Because we all need nekos in our lives.",
-                "Did someone call for a neko? :3"),
-            new WeebCmdInfo("nom", "nomnomnomnomnomnomnomnom",
-                "{0} got nomed on by {1}! omnomnom...", mentionsUser: true),
-            new WeebCmdInfo("owo", "OwO WHAT THE FUCK IS THIS",
-                "OwO"),
-            new WeebCmdInfo("pat", "Pats a person.",
-                "{0} got pat by {1}.", mentionsUser: true),
-            new WeebCmdInfo("poke", "Lets you poke a user and annoy them. >:3",
-                "Poke!", mentionsUser: true),
-            new WeebCmdInfo("pout", ":(",
-                ":C"),
-            new WeebCmdInfo("punch", "Punch someone in the face!",
-                "{0} got punched by {1}!", mentionsUser: true),
-            new WeebCmdInfo("shrug", @"¯\_(ツ)_/¯",
-                "Huh?"),
-            new WeebCmdInfo("slap", "Slaps a person.",
-                "{0} was slapped by {1}!", mentionsUser: true),
-            new WeebCmdInfo("sleepy", "I'm not sleepy, YOU'RE sleepy!",
-                "Yawn..."),
-            new WeebCmdInfo("smug", "Because all you weebs ever do is smug >:C",
-                "Heh."),
-            new WeebCmdInfo("stare", "👀",
-                "👀"),
-            new WeebCmdInfo("thumbsup", "Because you definitely need virtual thumbs",
-                "This has my approval."),
-            new WeebCmdInfo("tickle", "Tickles a person.",
-                "{0} was ticked to death by {1}!", mentionsUser: true),
-            new WeebCmdInfo("wag", "AWOOO 2: Electric Boogaloo",
-                ":3"),
-            /*
-             * @todo Move `discord` command from meme category to weeb category?
-             * @body Either way, it's just a weeb.sh command but with a different category. Dunno what to do about this one.
-             */
-        };
+        private const string FlagArgName = "flags";
+        private const string FlagArgDescription =
+            "Advanced options. Ask us if you really want to know how to use them.";
 
-        ICommandInfo[] IHasFakeCommands.FakeCommandInfo => Array.ConvertAll(FakeCommandInfo, cmdInfo => (ICommandInfo)cmdInfo);
-
-        private static readonly string[] FakeCommands = Array.ConvertAll(FakeCommandInfo, cmdInfo => cmdInfo.Name);
-        string[] IHasFakeCommands.FakeCommands => FakeCommands;
-
-        private readonly WeebClient WeebClient;
-
-        private const string EmbedFooter = "Powered by Weeb.sh!";
-        private const string FailureMsg = "Failed to retrieve image";
-        private const string FailureMsgNsfw = "This type probably has no NSFW images.";
-        private const string FailureMsgSearch = "There were probably no results for your search.";
-
-        /// <summary>
-        /// Await this task to wait for this to be ready to handle weeb.sh requests.
-        /// </summary>
-        internal Task Initialized;
-
-        Task INeedsInitialized.Initialize() => Initialized;
-
-        internal class WeebCmdsCtorArgs {
-            public string BotName { get; }
-            public string BotVersion { get; }
-            public string WeebToken { get; }
-            public WeebCmdsCtorArgs(string botName, string botVersion, string weebToken) {
-                BotName = botName;
-                BotVersion = botVersion;
-                WeebToken = weebToken;
+        [SlashCommandGroup("interact", "Interact with someone else")]
+        class MentionWeebs : ApplicationCommandModule
+        {
+            private const string UserArgDescription = "User to interact with";
+            
+            public WeebCommandsBase Base { private get; set; }
+        
+            public override async Task<bool> BeforeSlashExecutionAsync(InteractionContext ctx)
+            {
+                await Base.Initialized;
+                return true;
             }
+        
+            [SlashCommand("bite", "Bites the living HECK out of someone.")]
+            public async Task bite(InteractionContext ctx,
+                [Option("user", UserArgDescription)] DiscordUser user,
+                [Option(FlagArgName, FlagArgDescription)] string flagsStr = "") =>
+                await Base.FetchAndPostWithMention(ctx, "bite", "{0} was bit by {1}!", (DiscordMember)user, flagsStr);
+                
+            [SlashCommand("cuddle", "Cuddles a person.")]
+            public async Task cuddle(InteractionContext ctx,
+                [Option("user", UserArgDescription)] DiscordUser user,
+                [Option(FlagArgName, FlagArgDescription)] string flagsStr = "") =>
+                await Base.FetchAndPostWithMention(ctx, "cuddle", "{0} was cuddled by {1}.", (DiscordMember)user, flagsStr);
+                
+            [SlashCommand("hug", "Hugs a person.")]
+            public async Task hug(InteractionContext ctx,
+                [Option("user", UserArgDescription)] DiscordUser user,
+                [Option(FlagArgName, FlagArgDescription)] string flagsStr = "") =>
+                await Base.FetchAndPostWithMention(ctx, "hug", "{0} was hugged by {1}.", (DiscordMember)user, flagsStr);
+                
+            [SlashCommand("kiss", "Kisses a person.")]
+            public async Task kiss(InteractionContext ctx,
+                [Option("user", UserArgDescription)] DiscordUser user,
+                [Option(FlagArgName, FlagArgDescription)] string flagsStr = "") =>
+                await Base.FetchAndPostWithMention(ctx, "kiss", "{0} was kissed by {1}.", (DiscordMember)user, flagsStr);
+                
+            [SlashCommand("lick", "Licks a person.")]
+            public async Task lick(InteractionContext ctx,
+                [Option("user", UserArgDescription)] DiscordUser user,
+                [Option(FlagArgName, FlagArgDescription)] string flagsStr = "") =>
+                await Base.FetchAndPostWithMention(ctx, "lick", "{0} was licked by {1}!", (DiscordMember)user, flagsStr);
+                
+            [SlashCommand("nom", "nomnomnomnomnomnomnomnom")]
+            public async Task nom(InteractionContext ctx,
+                [Option("user", UserArgDescription)] DiscordUser user,
+                [Option(FlagArgName, FlagArgDescription)] string flagsStr = "") =>
+                await Base.FetchAndPostWithMention(ctx, "nom", "{0} got nomed on by {1}! omnomnom...", (DiscordMember)user, flagsStr);
+                
+            [SlashCommand("pat", "Pats a person.")]
+            public async Task pat(InteractionContext ctx,
+                [Option("user", UserArgDescription)] DiscordUser user,
+                [Option(FlagArgName, FlagArgDescription)] string flagsStr = "") =>
+                await Base.FetchAndPostWithMention(ctx, "pat", "{0} got pat by {1}.", (DiscordMember)user, flagsStr);
+                
+            [SlashCommand("poke", "Lets you poke a user and annoy them. >:3")]
+            public async Task poke(InteractionContext ctx,
+                [Option("user", UserArgDescription)] DiscordUser user,
+                [Option(FlagArgName, FlagArgDescription)] string flagsStr = "") =>
+                await Base.FetchAndPostWithMention(ctx, "poke", "Poke!", (DiscordMember)user, flagsStr);
+                
+            [SlashCommand("punch", "Punch someone in the face!")]
+            public async Task punch(InteractionContext ctx,
+                [Option("user", UserArgDescription)] DiscordUser user,
+                [Option(FlagArgName, FlagArgDescription)] string flagsStr = "") =>
+                await Base.FetchAndPostWithMention(ctx, "punch", "{0} got punched by {1}!", (DiscordMember)user, flagsStr);
+                
+            [SlashCommand("slap", "Slaps a person.")]
+            public async Task slap(InteractionContext ctx,
+                [Option("user", UserArgDescription)] DiscordUser user,
+                [Option(FlagArgName, FlagArgDescription)] string flagsStr = "") =>
+                await Base.FetchAndPostWithMention(ctx, "slap", "{0} was slapped by {1}!", (DiscordMember)user, flagsStr);
+                
+            [SlashCommand("tickle", "Tickles a person.")]
+            public async Task tickle(InteractionContext ctx,
+                [Option("user", UserArgDescription)] DiscordUser user,
+                [Option(FlagArgName, FlagArgDescription)] string flagsStr = "") =>
+                await Base.FetchAndPostWithMention(ctx, "tickle", "{0} was ticked to death by {1}!", (DiscordMember)user, flagsStr);
         }
 
-        public WeebCommands(WeebCmdsCtorArgs args) {
-            WeebClient = new WeebClient(BotName: args.BotName, BotVersion: args.BotVersion);
-            Initialized = WeebClient.Authenticate(args.WeebToken, TokenType.Wolke);
-        }
+        [SlashCommandGroup("solo", "Things performed alone")]
+        class SoloWeebs : ApplicationCommandModule
+        {
+            public WeebCommandsBase Base { private get; set; }
 
-        async Task IHasFakeCommands.HandleFakeCommand(CommandContext ctx, string cmdName) {
-            var cmdInfo = FakeCommandInfo.First(cmdInfo => cmdInfo.Name == cmdName);
-            var argStr = ctx.GetRawArgString(cmdName);
-            if (cmdInfo.MentionsUser) {
-                var flags = FlagArgs.ParseString(argStr, out var nonFlagsStr) ?? new FlagArgs();
-                var user = nonFlagsStr.Length == 0
-                    ? null
-                    : await Util.ConvertArgAsync<DiscordMember>(nonFlagsStr, ctx);
-                await BaseMention(ctx, user, type: cmdName, msg: cmdInfo.Msg, flags);
-            } else {
-                var flags = FlagArgs.ParseString(argStr) ?? new FlagArgs();
-                await Base(ctx, type: cmdName, msg: cmdInfo.Msg, flags);
+            public override async Task<bool> BeforeSlashExecutionAsync(InteractionContext ctx)
+            {
+                await Base.Initialized;
+                return true;
             }
-        }
-
-        private async Task Base(
-            CommandContext ctx,
-            string type,
-            string msg,
-            FlagArgs flags
-        ) {
-            await ctx.TriggerTypingAsync();
-
-            var requestTags = flags.Get("tags").NonEmpty()?.Split(',') ?? Array.Empty<string>();
-            var requestHidden = flags.ParseBool("hidden") ?? false;
-            var requestNsfw = ctx.Channel.IsNSFW
-                ? (flags.ParseEnum<NsfwSearch>("nsfw") ?? NsfwSearch.True)
-                : NsfwSearch.False;
-
-            var builder = new DiscordEmbedBuilder();
-            RandomData? image = await WeebClient.GetRandomAsync(
-                type: type,
-                tags: requestTags,
-                //fileType: FileType.Any,
-                hidden: requestHidden,
-                nsfw: requestNsfw
-            );
-            if (image == null) {
-                builder.WithTitle(FailureMsg);
-
-                if (requestTags.Length > 0 || requestHidden) {
-                    builder.WithDescription(FailureMsgSearch);
-                } else if (requestNsfw == NsfwSearch.Only) {
-                    builder.WithDescription(FailureMsgNsfw);
-                }
-            } else {
-                if (!ctx.Channel.IsNSFW && image.Nsfw) {
-                    await ctx.RespondAsync("For some reason Weeb.sh gave me a NSFW image, but this is a SFW channel!");
-                    return;
-                }
-
-                builder.WithTitle(msg).WithImageUrl(new Uri(image.Url));
-
-                if (flags.ParseBool("debug") ?? false) {
-                    var tagStr = Util.Join(image.Tags, tag => {
-                        var extraInfo = string.Join("; ", new string[] {
-                            tag.Hidden ? "hidden" : "",
-                            string.IsNullOrEmpty(tag.User) ? "" : $"user {tag.User}",
-                        }.Where(s => s.Length > 0));
-                        return tag.Name + (extraInfo.Length > 0
-                            ? $" ({extraInfo})"
-                            : "");
-                    });
-                    builder.AddField("Tags", tagStr, inline: true);
-
-                    var nsfwStr = image.Nsfw
-                        ? "yes"
-                        : (ctx.Channel.IsNSFW ? "no" : "not allowed in SFW channels");
-                    builder.AddField("NSFW", nsfwStr, inline: true);
-
-                    builder.AddField("Hidden", image.Hidden ? "yes" : "no", inline: true);
-                }
+            
+            [SlashCommand("get-types", "debugging"), SlashRequireOwner, Category(Category.Weeb)]
+            internal async Task GetTypes(InteractionContext ctx, [Option(FlagArgName, FlagArgDescription)] string flagsStr = "") {
+                var flags = FlagArgs.ParseString(flagsStr) ?? new FlagArgs();
+                var hidden = flags.ParseBool("hidden") ?? false;
+                TypesData? types = await Base.Client.GetTypesAsync(hidden: hidden);
+                await ctx.ReplyBasicAsync($"Types (includes hidden: {hidden}):\n" +
+                                          (types == null
+                                              ? "couldn't fetch types"
+                                              : string.Join(", ", types.Types.OrderBy(s => s))));
             }
-            builder.WithFooter(EmbedFooter);
-
-            await ctx.RespondAsync(embed: builder.Build());
-        }
-
-        private async Task BaseMention(
-            CommandContext ctx,
-            DiscordMember? user,
-            string type,
-            string msg,
-            FlagArgs flags
-        ) {
-            if (user == null) {
-                await ctx.RespondAsync("You didn't @mention any users!");
-            } else {
-                await Base(ctx, type: type, msg: string.Format(msg, user.DisplayName, ctx.Message.AuthorName()), flags);
-            }
-        }
-
-        [Command("get-types"), RequireOwner, Category(Category.Weeb)]
-        internal async Task GetTypes(CommandContext ctx, [RemainingText] FlagArgs flags = new FlagArgs()) {
-            var hidden = flags.ParseBool("hidden") ?? false;
-            TypesData? types = await WeebClient.GetTypesAsync(hidden: hidden);
-            await ctx.RespondAsync($"Types (includes hidden: {hidden}):\n" +
-                (types == null
-                    ? "couldn't fetch types"
-                    : string.Join(", ", types.Types.OrderBy(s => s))));
-        }
-
-        [Command("get-tags"), RequireOwner, Category(Category.Weeb)]
-        internal async Task GetTags(CommandContext ctx, [RemainingText] FlagArgs flags = new FlagArgs()) {
-            var hidden = flags.ParseBool("hidden") ?? false;
-            TagsData? tags = await WeebClient.GetTagsAsync(hidden: hidden);
-            await ctx.RespondAsync($"Tags (includes hidden: {hidden}):\n" +
-                (tags == null
-                    ? "couldn't fetch tags"
-                    : string.Join(", ", tags.Tags.OrderBy(s => s))));
-        }
-
-        internal struct WeebCmdInfo : ICommandInfo {
-            public string Name { get; }
-            public ImmutableArray<string> Aliases => ImmutableArray<string>.Empty;
-            public string Description { get; }
-            public Category Category => Category.Weeb;
-            public ImmutableArray<ICommandOverloadInfo> Overloads { get; }
-            public Command? Cmd => null;
-
-            public string Msg { get; }
-            public bool MentionsUser { get; }
-
-            private static readonly Regex FormatThingies = new Regex("{(?<num>\\d*)}");
-
-            [SuppressMessage("Globalization", "CA1303:Do not pass literals as localized parameters", Justification = "Only thrown at bot startup")]
-            public WeebCmdInfo(string type, string description, string msg, bool mentionsUser = false) {
-                Name = type;
-                Description = description;
-
-                if (msg.Contains("%s", StringComparison.Ordinal)) {
-                    throw new ArgumentException(paramName: nameof(msg),
-                        message: "You forgot to replace the '%s' things, dummy.");
-                }
-                var matches = FormatThingies.Matches(msg).AsEnumerable();
-                if (mentionsUser) {
-                    Overloads = ImmutableArray.Create(new[] {
-                        (ICommandOverloadInfo)new WeebOverloadMention()
-                    });
-                    foreach (var match in matches) {
-                        if (!int.TryParse(match.Groups["num"].Value, out var num) ||
-                            (num != 0 && num != 1)) {
-                            throw new ArgumentOutOfRangeException(paramName: nameof(msg),
-                                message: "Msg cannot reference substitutions other than 0 and 1");
-                        }
-                    }
-                } else {
-                    Overloads = ImmutableArray.Create(new[] {
-                        (ICommandOverloadInfo)new WeebOverload()
-                    });
-                    if (matches.Any()) {
-                        throw new ArgumentException(paramName: nameof(msg),
-                            message: "Msg cannot use substitutions when there are no mentions to substitute");
-                    }
-                }
-
-                Msg = msg;
-                MentionsUser = mentionsUser;
+            
+            [SlashCommand("get-tags", "debugging"), SlashRequireOwner, Category(Category.Weeb)]
+            internal async Task GetTags(InteractionContext ctx, [Option(FlagArgName, FlagArgDescription)] string flagsStr = "") {
+                var flags = FlagArgs.ParseString(flagsStr) ?? new FlagArgs();
+                var hidden = flags.ParseBool("hidden") ?? false;
+                TagsData? tags = await Base.Client.GetTagsAsync(hidden: hidden);
+                await ctx.ReplyBasicAsync($"Tags (includes hidden: {hidden}):\n" +
+                                          (tags == null
+                                              ? "couldn't fetch tags"
+                                              : string.Join(", ", tags.Tags.OrderBy(s => s))));
             }
 
-            public bool Equals([AllowNull] ICommandInfo other) => Name == other.Name;
+            [SlashCommand("awoo", "AWOOOOOOOOO")]
+            public async Task awoo(InteractionContext ctx,
+                [Option(FlagArgName, FlagArgDescription)] string flagsStr = "") =>
+                await Base.FetchAndPost(ctx, "awoo", "AWOOOOO", flagsStr);
+                
+            [SlashCommand("cry", ":(((((((")]
+            public async Task cry(InteractionContext ctx,
+                [Option(FlagArgName, FlagArgDescription)] string flagsStr = "") =>
+                await Base.FetchAndPost(ctx, "cry", ":CCCCCCC", flagsStr);
+                
+            [SlashCommand("dab", "<o/")]
+            public async Task dab(InteractionContext ctx,
+                [Option(FlagArgName, FlagArgDescription)] string flagsStr = "") =>
+                await Base.FetchAndPost(ctx, "dab", @"<o/ \o>", flagsStr);
+                
+            [SlashCommand("dance", "ᕕ( ᐛ )ᕗ")]
+            public async Task dance(InteractionContext ctx,
+                [Option(FlagArgName, FlagArgDescription)] string flagsStr = "") =>
+                await Base.FetchAndPost(ctx, "dance", "ᕕ( ᐛ )ᕗ", flagsStr);
+                
+            [SlashCommand("deredere", "Because we couldn't get a tsundere command")]
+            public async Task deredere(InteractionContext ctx,
+                [Option(FlagArgName, FlagArgDescription)] string flagsStr = "") =>
+                await Base.FetchAndPost(ctx, "deredere", "❤❤❤❤", flagsStr);
+                
+            [SlashCommand("lewd", "For those l-lewd moments...")]
+            public async Task lewd(InteractionContext ctx,
+                [Option(FlagArgName, FlagArgDescription)] string flagsStr = "") =>
+                await Base.FetchAndPost(ctx, "lewd", "Did someone say l-lewd?", flagsStr);
+                
+            [SlashCommand("neko", "Because we all need nekos in our lives.")]
+            public async Task neko(InteractionContext ctx,
+                [Option(FlagArgName, FlagArgDescription)] string flagsStr = "") =>
+                await Base.FetchAndPost(ctx, "neko", "Did someone call for a neko? :3", flagsStr);
+                
+            [SlashCommand("owo", "OwO WHAT THE FUCK IS THIS")]
+            public async Task owo(InteractionContext ctx,
+                [Option(FlagArgName, FlagArgDescription)] string flagsStr = "") =>
+                await Base.FetchAndPost(ctx, "owo", "OwO", flagsStr);
+                
+            [SlashCommand("pout", ":(")]
+            public async Task pout(InteractionContext ctx,
+                [Option(FlagArgName, FlagArgDescription)] string flagsStr = "") =>
+                await Base.FetchAndPost(ctx, "pout", ":C", flagsStr);
+                
+            [SlashCommand("shrug", @"¯\_(ツ)_/¯")]
+            public async Task shrug(InteractionContext ctx,
+                [Option(FlagArgName, FlagArgDescription)] string flagsStr = "") =>
+                await Base.FetchAndPost(ctx, "shrug", "Huh?", flagsStr);
+                
+            [SlashCommand("sleepy", "I'm not sleepy, YOU'RE sleepy!")]
+            public async Task sleepy(InteractionContext ctx,
+                [Option(FlagArgName, FlagArgDescription)] string flagsStr = "") =>
+                await Base.FetchAndPost(ctx, "sleepy", "Yawn...", flagsStr);
+                
+            [SlashCommand("smug", "Because all you weebs ever do is smug >:C")]
+            public async Task smug(InteractionContext ctx,
+                [Option(FlagArgName, FlagArgDescription)] string flagsStr = "") =>
+                await Base.FetchAndPost(ctx, "smug", "Heh.", flagsStr);
+                
+            [SlashCommand("stare", "👀")]
+            public async Task stare(InteractionContext ctx,
+                [Option(FlagArgName, FlagArgDescription)] string flagsStr = "") =>
+                await Base.FetchAndPost(ctx, "stare", "👀", flagsStr);
+                
+            [SlashCommand("thumbsup", "Because you definitely need virtual thumbs")]
+            public async Task thumbsup(InteractionContext ctx,
+                [Option(FlagArgName, FlagArgDescription)] string flagsStr = "") =>
+                await Base.FetchAndPost(ctx, "thumbsup", "This has my approval.", flagsStr);
+                
+            [SlashCommand("wag", "AWOOO 2: Electric Boogaloo")]
+            public async Task wag(InteractionContext ctx,
+                [Option(FlagArgName, FlagArgDescription)] string flagsStr = "") =>
+                await Base.FetchAndPost(ctx, "wag", ":3", flagsStr);
         }
-
-        internal struct WeebOverload : ICommandOverloadInfo {
-            public ImmutableArray<ICommandArgumentInfo> Arguments => ImmutableArray.Create(new[] {
-                (ICommandArgumentInfo)new WeebArgFlags()
-            });
-            public int Priority => 0;
-        }
-
-        internal struct WeebOverloadMention : ICommandOverloadInfo {
-            public ImmutableArray<ICommandArgumentInfo> Arguments => ImmutableArray.Create(new[] {
-                // Flags are parsed before this arg
-                (ICommandArgumentInfo)new WeebArgMention()
-            });
-            public int Priority => 0;
-        }
-
-        internal struct WeebArgFlags : ICommandArgumentInfo {
-            public string Name => "flags";
-            public string Description => "";
-            public bool IsOptional => true;
-            public bool IsHidden => true;
-        }
-
-        internal struct WeebArgMention : ICommandArgumentInfo {
-            public string Name => "user";
-            public string Description => "@user";
-            public bool IsOptional => false;
-            public bool IsHidden => false;
-        }
+        
+        /*
+         * @todo Move `discord` command from meme category to weeb category?
+         * @body Either way, it's just a weeb.sh command but with a different category. Dunno what to do about this one.
+         */
 
     }
 }

--- a/KekBot/KekBot.cs
+++ b/KekBot/KekBot.cs
@@ -25,6 +25,7 @@ using System.Collections;
 using DSharpPlus.Interactivity.Extensions;
 using Microsoft.Extensions.Logging;
 using DSharpPlus.Exceptions;
+using DSharpPlus.SlashCommands;
 
 namespace KekBot {
     /// <summary>
@@ -144,11 +145,15 @@ namespace KekBot {
             CommandsNext.RegisterConverter(new FlagsConverter());
 
             CommandsNext.RegisterCommands<TestCommand>();
-            CommandsNext.RegisterCommands<PingCommand>();
             CommandsNext.RegisterCommands<OwnerCommands>();
             CommandsNext.RegisterCommands<HelpCommand>();
             CommandsNext.RegisterCommands<FunCommands>();
             CommandsNext.RegisterCommands<MemeCommands>();
+            
+            // Put your guild ID here if you wanna test
+            ulong? testGuildId = null;
+            var slash = Discord.UseSlashCommands();
+            slash.RegisterCommands<PingCommand>(testGuildId);
 
             if (config.WeebToken == null) {
                 Discord.Logger.Log(LogLevel.Information, $"[{LOGTAG}-{ShardID}] NOT registering weeb commands because no token was found >:(", DateTime.Now);

--- a/KekBot/KekBot.csproj
+++ b/KekBot/KekBot.csproj
@@ -17,11 +17,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DSharpPlus" Version="4.1.0-nightly-00915" />
-    <PackageReference Include="DSharpPlus.CommandsNext" Version="4.1.0-nightly-00915" />
-    <PackageReference Include="DSharpPlus.Interactivity" Version="4.1.0-nightly-00915" />
-    <PackageReference Include="DSharpPlus.Lavalink" Version="4.1.0-nightly-00915" />
-    <PackageReference Include="DSharpPlus.VoiceNext" Version="4.1.0-nightly-00915" />
+    <PackageReference Include="DSharpPlus" Version="4.2.0-nightly-01030" />
+    <PackageReference Include="DSharpPlus.CommandsNext" Version="4.2.0-nightly-01030" />
+    <PackageReference Include="DSharpPlus.Interactivity" Version="4.2.0-nightly-01030" />
+    <PackageReference Include="DSharpPlus.Lavalink" Version="4.2.0-nightly-01030" />
+    <PackageReference Include="DSharpPlus.SlashCommands" Version="4.2.0-nightly-01030" />
+    <PackageReference Include="DSharpPlus.VoiceNext" Version="4.2.0-nightly-01030" />
     <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="8.0.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.2">
       <PrivateAssets>all</PrivateAssets>

--- a/KekBot/Lib/INeedsInitialized.cs
+++ b/KekBot/Lib/INeedsInitialized.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 
 namespace KekBot.Lib {
+    /// Note: this will NOT work for slash commands.
     interface INeedsInitialized {
 
         Task Initialize();

--- a/KekBot/Lib/WeebCommandsBase.cs
+++ b/KekBot/Lib/WeebCommandsBase.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using DSharpPlus.Entities;
+using DSharpPlus.SlashCommands;
+using KekBot.Arguments;
+using KekBot.Utils;
+using Weeb.net;
+using Weeb.net.Data;
+
+namespace KekBot.Lib
+{
+    public class WeebCommandsBase
+    {
+        public WeebClient Client { get; }
+        /// <summary>
+        /// Await this task to wait for this to be ready to handle weeb.sh requests.
+        /// </summary>
+        public Task Initialized { get; }
+        
+        private const string EmbedFooter = "Powered by Weeb.sh!";
+        private const string FailureMsg = "Failed to retrieve image";
+        private const string FailureMsgNsfw = "This type probably has no NSFW images.";
+        private const string FailureMsgSearch = "There were probably no results for your search.";
+
+        public WeebCommandsBase(string botName, string botVersion, string weebToken)
+        {
+            Client = new WeebClient(botName, botVersion);
+            Initialized = Client.Authenticate(weebToken, TokenType.Wolke);
+        }
+        
+        public async Task FetchAndPost(
+            InteractionContext ctx,
+            string type,
+            string msg,
+            string flagsStr
+        )
+        {
+            await ctx.SendThinking();
+
+            var flags = FlagArgs.ParseString(flagsStr) ?? new FlagArgs();
+
+            var requestTags = flags.Get("tags").NonEmpty()?.Split(',') ?? Array.Empty<string>();
+            var requestHidden = flags.ParseBool("hidden") ?? false;
+            var requestNsfw = ctx.Channel.IsNSFW
+                ? (flags.ParseEnum<NsfwSearch>("nsfw") ?? NsfwSearch.True)
+                : NsfwSearch.False;
+
+            var builder = new DiscordEmbedBuilder();
+            RandomData? image = await Client.GetRandomAsync(
+                type: type,
+                tags: requestTags,
+                //fileType: FileType.Any,
+                hidden: requestHidden,
+                nsfw: requestNsfw
+            );
+            if (image == null) {
+                builder.WithTitle(FailureMsg);
+
+                if (requestTags.Length > 0 || requestHidden) {
+                    builder.WithDescription(FailureMsgSearch);
+                } else if (requestNsfw == NsfwSearch.Only) {
+                    builder.WithDescription(FailureMsgNsfw);
+                }
+            } else {
+                if (!ctx.Channel.IsNSFW && image.Nsfw)
+                {
+                    await ctx.ReplyBasicAsync(
+                        "For some reason Weeb.sh gave me a NSFW image, but this is a SFW channel!");
+                    return;
+                }
+
+                builder.WithTitle(msg).WithImageUrl(new Uri(image.Url));
+
+                if (flags.ParseBool("debug") ?? false) {
+                    var tagStr = Util.Join(image.Tags, tag => {
+                        var extraInfo = string.Join("; ", new string[] {
+                            tag.Hidden ? "hidden" : "",
+                            string.IsNullOrEmpty(tag.User) ? "" : $"user {tag.User}",
+                        }.Where(s => s.Length > 0));
+                        return tag.Name + (extraInfo.Length > 0
+                            ? $" ({extraInfo})"
+                            : "");
+                    });
+                    builder.AddField("Tags", tagStr, inline: true);
+
+                    var nsfwStr = image.Nsfw
+                        ? "yes"
+                        : (ctx.Channel.IsNSFW ? "no" : "not allowed in SFW channels");
+                    builder.AddField("NSFW", nsfwStr, inline: true);
+
+                    builder.AddField("Hidden", image.Hidden ? "yes" : "no", inline: true);
+                }
+            }
+            builder.WithFooter(EmbedFooter);
+            
+            await ctx.EditResponseAsync(new DiscordWebhookBuilder().AddEmbed(builder.Build()));
+        }
+        
+        public async Task FetchAndPostWithMention(
+            InteractionContext ctx,
+            string type,
+            string msg,
+            DiscordMember user,
+            string flagsStr
+        ) => await FetchAndPost(
+            ctx,
+            type: type, 
+            msg: string.Format(msg, user.DisplayName, ctx.Interaction.User.GetName()),
+            flagsStr: flagsStr
+        );
+    }
+}

--- a/KekBot/Utils/CommandExtensions.cs
+++ b/KekBot/Utils/CommandExtensions.cs
@@ -1,5 +1,9 @@
 ﻿using System.Linq;
+using System.Threading.Tasks;
+using DSharpPlus;
 using DSharpPlus.CommandsNext;
+using DSharpPlus.Entities;
+using DSharpPlus.SlashCommands;
 using KekBot.Attributes;
 
 namespace KekBot {
@@ -15,5 +19,33 @@ namespace KekBot {
             arg?.CustomAttributes.OfType<HiddenParam>().Any() ?? false;
 
         public static string? GetExtendedDescription(this Command cmd) => cmd?.CustomAttributes.OfType<ExtendedDescriptionAttribute>().FirstOrDefault()?.ExtendedDescription;
+        
+        /// <summary>
+        /// Delays the reply to the user.
+        /// After doing so, you can reply within 15 minutes using <see cref="InteractionContext.FollowUpAsync(DiscordFollowupMessageBuilder)"/>
+        /// </summary>
+        /// <param name="ctx">The interaction context</param>
+        /// <returns></returns>
+        internal static async Task SendThinking(this InteractionContext ctx) =>
+            await ctx.CreateResponseAsync(InteractionResponseType.DeferredChannelMessageWithSource);
+
+        /// <summary>
+        /// Sends a response to the command recieved. For messages that consist of a basic string, see <seealso cref="ReplyBasicAsync(InteractionContext, string, bool)"/>
+        /// </summary>
+        /// <param name="ctx">The interaction context</param>
+        /// <param name="builder">The interaction response builder</param>
+        /// <returns></returns>
+        internal static async Task ReplyAsync(this InteractionContext ctx, DiscordInteractionResponseBuilder builder) =>
+            await ctx.CreateResponseAsync(InteractionResponseType.ChannelMessageWithSource, builder);
+
+        /// <summary>
+        /// Sends a response to the command recieved.
+        /// </summary>
+        /// <param name="ctx">The interaction context</param>
+        /// <param name="content">The content of the response</param>
+        /// <param name="ephemeral">Whether or not the response is ephemeral</param>
+        /// <returns></returns>
+        internal static async Task ReplyBasicAsync(this InteractionContext ctx, string content, bool ephemeral = false) =>
+            await ctx.ReplyAsync(new DiscordInteractionResponseBuilder().WithContent(content).AsEphemeral(ephemeral));
     }
 }

--- a/KekBot/Utils/Util.cs
+++ b/KekBot/Utils/Util.cs
@@ -105,10 +105,10 @@ namespace KekBot.Utils {
         internal static int FastIndexOfEnd(this string s, string value, int startIndex = 0) =>
             s.IndexOfEnd(value, startIndex, StringComparison.Ordinal);
 
-        internal static string AuthorName(this DiscordMessage msg) => msg.Author switch {
-            DiscordMember m => m.DisplayName,
-            DiscordUser u => u.Username,
-        };
+        internal static string GetName(this DiscordUser user) =>
+            user is DiscordMember m ? m.DisplayName : user.Username;
+
+        internal static string AuthorName(this DiscordMessage msg) => msg.Author.GetName();
 
         internal static string GetRawArgString(this CommandContext ctx, string cmdName) =>
             ctx.Message.GetRawArgString(ctx.Prefix, cmdName);


### PR DESCRIPTION
I converted the weeb.sh commands to slash commands. There's a top level group called "weeb", which has two subgroups, "solo" and "interact". The actual subcommands are placed under them depending on whether they involve a second user.

Since the arguments to a slash command don't really exist as a message, interaction commands don't ping the person now. Perhaps the reply should ping them?

Note: this is meant to be merged after #105 