### PR TITLE
Create template Config file if one cannot be found

### DIFF
--- a/KekBot/Config.cs
+++ b/KekBot/Config.cs
@@ -37,7 +37,6 @@ namespace KekBot {
             blank.DbPass = "database password";
             blank.Shards = 2;
             blank.RankedUsers = new Dictionary<ulong, Rank>();
-            blank.WeebToken = "weebToken";
             return blank;
         }
 

--- a/KekBot/KekBot.cs
+++ b/KekBot/KekBot.cs
@@ -159,7 +159,7 @@ namespace KekBot {
             });
             slash.RegisterCommands<PingCommand>(testGuildId);
 
-            if (config.WeebToken == null || config.WeebToken == "weebToken") {
+            if (config.WeebToken == null) {
                 Discord.Logger.Log(LogLevel.Information, $"[{LOGTAG}-{ShardID}] NOT registering weeb commands because no token was found >:(", DateTime.Now);
             } else {
                 Discord.Logger.Log(LogLevel.Information, $"[{LOGTAG}-{ShardID}] Initializing weeb commands", DateTime.Now);


### PR DESCRIPTION
Previously, the bot would just crash if it couldn't fine one. This creates a very basic config file full of dummy values for the user to edit.

This also removes the need for the user to guess the config file layout while making their own as well.